### PR TITLE
Fix gcc warnings about void* conversion

### DIFF
--- a/vstring.h
+++ b/vstring.h
@@ -72,9 +72,9 @@ vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
 	if ((type & VS_TYPE_DYNAMIC)) {
 		if (vs == NULL) {
 			if (vm != NULL) {
-				vs = vm->vs_malloc(sizeof (*vs));
+				vs = (vstring *)vm->vs_malloc(sizeof (*vs));
 			} else {
-				vs = calloc(1, sizeof (*vs));
+				vs = (vstring *)calloc(1, sizeof (*vs));
 			}
 			vs->flags |= VS_NEEDSFREE;
 		} else {
@@ -96,9 +96,9 @@ vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
 
 		if (vs == NULL) {
 			if (vm != NULL) {
-				vs = vm->vs_malloc(sizeof (*vs));
+				vs = (vstring *)vm->vs_malloc(sizeof (*vs));
 			} else {
-				vs = calloc(1, sizeof (*vs));
+				vs = (vstring *)calloc(1, sizeof (*vs));
 			}
 			vs->flags |= VS_NEEDSFREE;
 		} else {
@@ -165,9 +165,9 @@ vs_resize(vstring *vs, size_t hint)
 		}
 
 		if (vs->vm.vs_malloc) {
-			vs->contents = vs->vm.vs_malloc(vs->size);
+			vs->contents = (char *)vs->vm.vs_malloc(vs->size);
 		} else {
-			vs->contents = calloc(1, vs->size);
+			vs->contents = (char *)calloc(1, vs->size);
 		}
 	} else {
 		size_t size = vs->size * 2;
@@ -180,9 +180,9 @@ vs_resize(vstring *vs, size_t hint)
 			vs->type = VS_TYPE_DYNAMIC;
 
 			if (vs->vm.vs_malloc) {
-				tmp = vs->vm.vs_malloc(size);
+				tmp = (char *)vs->vm.vs_malloc(size);
 			} else {
-				tmp = calloc(1, size);
+				tmp = (char *)calloc(1, size);
 			}
 
 			memcpy(tmp, vs->contents, vs->size);
@@ -190,9 +190,9 @@ vs_resize(vstring *vs, size_t hint)
 			vs->size = size;
 		} else if ((vs->type & VS_TYPE_DYNAMIC)) {
 			if (vs->vm.vs_realloc) {
-				tmp = vs->vm.vs_realloc(vs->contents, size * 2);
+				tmp = (char *)vs->vm.vs_realloc(vs->contents, size * 2);
 			} else {
-				tmp = realloc(vs->contents, size * 2);
+				tmp = (char *)realloc(vs->contents, size * 2);
 			}
 			if (tmp != NULL) {
 				vs->contents = tmp;


### PR DESCRIPTION
Hi, I got several warnings on `gcc -Wall -std=c99`.
It was about converting void* implicitly, so I added some cast operators to make compiler happy.

```
deps/vstring/vstring.h: In function 'vstring* vs_init(vstring*, vstring_malloc*, vstring_type, char*, size_t)':
deps/vstring/vstring.h:75:36: warning: invalid conversion from 'void*' to 'vstring*' [-fpermissive]
     vs = vm->vs_malloc(sizeof (*vs));
                                    ^
deps/vstring/vstring.h:77:32: warning: invalid conversion from 'void*' to 'vstring*' [-fpermissive]
     vs = calloc(1, sizeof (*vs));
                                ^
deps/vstring/vstring.h:99:36: warning: invalid conversion from 'void*' to 'vstring*' [-fpermissive]
     vs = vm->vs_malloc(sizeof (*vs));
                                    ^
deps/vstring/vstring.h:101:32: warning: invalid conversion from 'void*' to 'vstring*' [-fpermissive]
     vs = calloc(1, sizeof (*vs));
                                ^
deps/vstring/vstring.h: In function 'void* vs_resize(vstring*, size_t)':
deps/vstring/vstring.h:168:44: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
    vs->contents = vs->vm.vs_malloc(vs->size);
                                            ^
deps/vstring/vstring.h:170:37: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
    vs->contents = calloc(1, vs->size);
                                     ^
deps/vstring/vstring.h:183:32: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
     tmp = vs->vm.vs_malloc(size);
                                ^
deps/vstring/vstring.h:185:25: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
     tmp = calloc(1, size);
                         ^
deps/vstring/vstring.h:193:51: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
     tmp = vs->vm.vs_realloc(vs->contents, size * 2);
                                                   ^
deps/vstring/vstring.h:195:41: warning: invalid conversion from 'void*' to 'char*' [-fpermissive]
     tmp = realloc(vs->contents, size * 2);
                                         ^
```