### PR TITLE
Wrap inline keyword into a macro for non-modern compilers

### DIFF
--- a/vstring.h
+++ b/vstring.h
@@ -34,6 +34,17 @@
 #include <string.h>
 #include <math.h>
 
+#ifndef vstring_inline
+#  if defined(_MSC_VER) || defined(__BORLANDC__) || \
+  defined(__DMC__) || defined(__SC__) || \
+  defined(__WATCOMC__) || defined(__LCC__) || \
+  defined(__DECC) || defined(__EABI__)
+#    define vstring_inline __inline
+#  else
+#    define vstring_inline inline
+#  endif
+#endif
+
 typedef struct vstring_malloc {
 	void		*(*vs_malloc)(size_t);
 	void		*(*vs_realloc)(void *, size_t);
@@ -64,7 +75,7 @@ enum vstring_flags {
 	VS_NEEDSFREE	= 1, /* Set if the API needs to free the vs itself */
 };
 
-static inline vstring *
+static vstring_inline vstring *
 vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
     size_t size)
 {
@@ -121,7 +132,7 @@ vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
 	return vs;
 }
 
-static inline void
+static vstring_inline void
 vs_deinit(vstring *vs)
 {
 
@@ -145,14 +156,14 @@ vs_deinit(vstring *vs)
 	}
 }
 
-static inline void
+static vstring_inline void
 vs_rewind(vstring *vs)
 {
 
 	vs->pointer = 0;
 }
 
-static inline void *
+static vstring_inline void *
 vs_resize(vstring *vs, size_t hint)
 {
 	char *tmp;
@@ -211,7 +222,7 @@ vs_resize(vstring *vs, size_t hint)
 	return vs->contents;
 }
 
-static inline bool
+static vstring_inline bool
 vs_push(vstring *vs, char c)
 {
 
@@ -225,7 +236,7 @@ vs_push(vstring *vs, char c)
 	return true;
 }
 
-static inline bool
+static vstring_inline bool
 vs_pushstr(vstring *vs, const char *s, uint64_t len)
 {
 
@@ -244,7 +255,7 @@ vs_pushstr(vstring *vs, const char *s, uint64_t len)
 	return true;
 }
 
-static inline bool
+static vstring_inline bool
 vs_pushuint(vstring *vs, uint64_t n)
 {
 	char buf[20];
@@ -272,7 +283,7 @@ vs_pushuint(vstring *vs, uint64_t n)
 	}
 }
 
-static inline bool
+static vstring_inline bool
 vs_pushint(vstring *vs, int64_t n)
 {
 	char buf[21];
@@ -309,7 +320,7 @@ vs_pushint(vstring *vs, int64_t n)
 	}
 }
 
-static inline bool
+static vstring_inline bool
 vs_padint(vstring *vs, uint64_t n, int places)
 {
 	char buf[20];
@@ -343,7 +354,7 @@ vs_padint(vstring *vs, uint64_t n, int places)
 	return vs_pushstr(vs, buf, l + 1);
 }
 
-static inline bool
+static vstring_inline bool
 vs_pushdouble(vstring *vs, double n)
 {
 	double modf_int, modf_frac;
@@ -379,21 +390,21 @@ vs_pushdouble(vstring *vs, double n)
 	}
 }
 
-static inline bool
+static vstring_inline bool
 vs_finalize(vstring *vs)
 {
 
 	return vs_push(vs, '\0');
 }
 
-static inline char *
+static vstring_inline char *
 vs_contents(vstring *vs)
 {
 
 	return vs->contents;
 }
 
-static inline uint64_t
+static vstring_inline uint64_t
 vs_len(vstring *vs)
 {
 


### PR DESCRIPTION
Hi,
Bare 'inline' keyword are still not supported on MSVC and some of other compilers despite they support '__inline.'
Wrapping the keyword into a macro helps them.