### PR TITLE
Need to clear memory in case vs_malloc() don't

### DIFF
--- a/test.c
+++ b/test.c
@@ -38,8 +38,10 @@ void *
 tmalloc(size_t s)
 {
 
+	void *m = malloc(s);
 	allocs++;
-	return calloc(1, s);
+	memset(m, 0xA, s);
+	return m;
 }
 
 void *
@@ -109,6 +111,11 @@ main(void)
 	vm.vs_realloc = trealloc;
 	vm.vs_free = tfree;
 	vs = vs_init(vs, &vm, VS_TYPE_DYNAMIC, NULL, 0);
+	assert(vs->type == 1);
+	assert(vs->flags == VS_NEEDSFREE);
+	assert(vs_len(vs) == 0);
+	assert(vs_contents(vs) == NULL);
+	assert(vs->size == 0);
 	assert(vs_push(vs, 'a'));
 	assert(vs_push(vs, 'b'));
 	for (int i = vs_len(vs); i < 257; i++) {

--- a/vstring.h
+++ b/vstring.h
@@ -73,6 +73,7 @@ vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
 		if (vs == NULL) {
 			if (vm != NULL) {
 				vs = vm->vs_malloc(sizeof (*vs));
+				memset(vs, 0, sizeof (*vs));
 			} else {
 				vs = calloc(1, sizeof (*vs));
 			}
@@ -97,6 +98,7 @@ vs_init(vstring *vs, vstring_malloc *vm, enum vstring_type type, char *buf,
 		if (vs == NULL) {
 			if (vm != NULL) {
 				vs = vm->vs_malloc(sizeof (*vs));
+				memset(vs, 0, sizeof (*vs));
 			} else {
 				vs = calloc(1, sizeof (*vs));
 			}


### PR DESCRIPTION
Hi,
I got a crash at `vs_push()` with custom malloc.
The problem is that `vs_init()` expects `vs_malloc` to clear memory, leaving some members uninitialized.
I added test to confirm and put `memset` for them.